### PR TITLE
responsive classes were excluded to prevent conflicts.

### DIFF
--- a/includes/youtube-lazyload-function.php
+++ b/includes/youtube-lazyload-function.php
@@ -16,7 +16,7 @@ function ucf_lazyload_youtube_oembed_filter($html, $url, $attr) {
 
         ob_start();
         ?>
-        <div class="youtube-preview embed-responsive embed-responsive-16by9" data-video-id="<?php echo $video_id; ?>" tabindex="0" role="button" aria-label="Play video">
+        <div class="youtube-preview" data-video-id="<?php echo $video_id; ?>" tabindex="0" role="button" aria-label="Play video">
             <div class="embed-responsive-item overflow-hidden">
                 <img
                     src="<?php echo esc_url($thumbnail_url); ?>"


### PR DESCRIPTION
**Description**
Historically, whenever we used a YouTube video, we wrapped it with ```<div class="embed-responsive embed-responsive-16by9 mb-3">```
 To prevent conflicts, we should remove the```embed-responsive embed-responsive-16by9``` classes from plugin. 

**How Has This Been Tested?**
Tested on Local

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
