### PR TITLE
Fontawesome play button replaced with SVG graphics.

### DIFF
--- a/includes/youtube-lazyload-function.php
+++ b/includes/youtube-lazyload-function.php
@@ -30,8 +30,11 @@ function ucf_lazyload_youtube_oembed_filter($html, $url, $attr) {
                     loading="lazy"
                 />
                 <div class="play-button" aria-label="Play video">
-                    <i class="fa-solid fa-circle-play rounded-circle bg-secondary box-shadow-soft-inverse fa-3x"></i>
-                    <span class="sr-only">Play video</span>
+					<svg viewBox="0 0 64 64" width="58" height="58" role="img" aria-label="Play video">
+						<circle cx="32" cy="32" r="30" fill="#FF0000"/>
+						<polygon points="25,18 25,46 46,32" fill="#FFFFFF"/>
+					</svg>
+					<span class="sr-only">Play video</span>
                 </div>
             </div>
         </div>

--- a/includes/youtube-lazyload-function.php
+++ b/includes/youtube-lazyload-function.php
@@ -17,7 +17,7 @@ function ucf_lazyload_youtube_oembed_filter($html, $url, $attr) {
         }
 
         $video_id = esc_attr($matches[1]);
-        $thumbnail_url = "https://img.youtube.com/vi/{$video_id}/hqdefault.jpg";
+        $thumbnail_url = "https://img.youtube.com/vi/{$video_id}/sddefault.jpg";
 
         ob_start();
         ?>


### PR DESCRIPTION
**Description**
Since we are using the lazyload plugin widely across different theme files, we can reduce dependencies as much as possible to make it more robust. In this example, we can remove the Font Awesome dependency and replace the play icon with an SVG.

<img width="1110" height="502" alt="Screenshot 2025-08-20 at 2 13 07 PM" src="https://github.com/user-attachments/assets/30a48087-0b5a-48a1-a000-44e13a6d55e8" />

**How Has This Been Tested?**
Tested local.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
